### PR TITLE
Add metadata field to `Learner`

### DIFF
--- a/src/learner.jl
+++ b/src/learner.jl
@@ -22,6 +22,7 @@ mutable struct Learner
     step::PropDict
     callbacks::Callbacks
     cbstate::PropDict
+    metadata::PropDict
 end
 
 
@@ -68,6 +69,10 @@ Keyword arguments (optional):
     save state to for other callbacks. Its keys depend on what callbacks
     are being used. See the [custom callbacks guide](/documents/docs/callbacks/custom.md)
     for more info.
+- `metadata::`[`PropDict`](#): A container to hold useful metadata associated
+    with the `Learner`. Defaults to an empty container for standard training.
+    This can be useful for storing hyper-parameters for
+    unconventional custom training methods.
 """
 function Learner(model, lossfn; callbacks = [], data = (), optimizer = ADAM(), kwargs...)
     return Learner(model, data, optimizer, lossfn, callbacks...; kwargs...)
@@ -101,6 +106,7 @@ function Learner(
         setupoptimstate(model, optimizer),
         PropDict(),
         cbs,
+        PropDict(),
         PropDict())
     init!(cbs, learner)
     return learner


### PR DESCRIPTION
This adds a "metadata" `PropDict` to `Learner` for storing information that is required for training but extraneous to the training state or callback state. This is useful for unconventional training methods (issue that I am currently dealing with). In the same way that the loss function is a "parameter" that needs to be specified to standard supervised training, the metadata field holds parameters that need to be specified for unconventional training. Of course, we can't know what these parameters will be like standard training, so instead of explicit names, we provide a container to hold them.