### PR TITLE
How not to print docstring

### DIFF
--- a/docs/callbacks/reference.md
+++ b/docs/callbacks/reference.md
@@ -10,8 +10,8 @@
 | [`Recorder`](#)*        | Records training stats like number of steps and epochs              |
 | [`ProgressPrinter`](#)* | Prints a progress bar for the current epoch during training         |
 | [`MetricsPrinter`](#)*  | Prints out metrics after every epoch                                |
-| [`SanityCheck`](#)*     | Performs sanity checks on data, model and loss before training      |
-| [`StopOnNaNLoss`](#)    | Stops training early if a step loss is `NaN`                        |
+| [`StopOnNaNLoss`](#)*   | Stops training early if a step loss is `NaN`                        |
+| [`SanityCheck`](#)      | Performs sanity checks on data, model and loss before training      |
 | [`ToGPU`](#)            | Trains using a CUDA GPU if available                                |
 | [`Checkpointer`](#)     | Saves the model after every epoch                                   |
 | [`EarlyStopping`](#)    | Stops training early when a criterion is met                        |
@@ -21,19 +21,22 @@
 | [`LogVisualization`](#) | Logs visualization to a logging backend                             |
 | [`LogHistograms`](#)    | Logs model weight histograms to a logging backend                   |
 
-
-There are also some utilities for creating callbacks:
-
-- [`CustomCallback`](#) to quickly hook a function into an event
-- [`throttle`](#) to run a callback only after every `n` events or every `t` seconds
-
-And for working with callbacks on an existing [`Learner`](#):
+To construct a learner without default callbacks, pass `usedefaultcallbacks=false` when constructing it.   
+For working with callbacks on an existing [`Learner`](#), see:
 
 - [`setcallbacks!`](#)
 - [`addcallback!`](#)
 - [`getcallback`](#)
 - [`replacecallback!`](#)
 - [`removecallback!`](#)
+
+
+There are also some utilities for creating callbacks:
+
+- [`CustomCallback`](#) to quickly hook a function into an event
+- [`throttle`](#) to run a callback only after every `n` events or every `t` seconds
+
+
 
 
 ## Extension API

--- a/docs/callbacks/usage.md
+++ b/docs/callbacks/usage.md
@@ -18,7 +18,8 @@ learner = Learner(
     callbacks=[ToGPU(), Metrics(accuracy)], data=data)      # pass any number of callbacks as additional arguments
 ```
 
-Some useful callbacks are added by default:
+Some useful callbacks are added by default. Below, the callbacks of `learner` are shown. Both the explicitly passed callbacks
+and the default ones are included:
 
 {cell=main, output=false}
 ```julia


### PR DESCRIPTION
This PR removes the star indicating default callbacks on `SanityCheck`, and adds it to `StopOnNaNLoss`, based on
```
(DennisBachelorProject) pkg> st FluxTraining
      Status `C:\Users\Dennis Bal\DennisBachelorProject\Project.toml`
  [7bf95e4d] FluxTraining v0.3.2

julia> lr = Learner(predict, lossfn)
Learner()

julia> lr.callbacks.cbs
5-element Vector{FluxTraining.SafeCallback}:
 ProgressPrinter()
 MetricsPrinter()
 StopOnNaNLoss()
 Recorder()
 Metrics(Loss())
```
, which is consistent with the automated output in the [docs](https://fluxml.ai/FluxTraining.jl/dev/documents/docs/callbacks/usage.md)
It also adds a sentence on constructing learners without default callbacks, and changed the order (and singltly wording) on the two paragraphs after the table.

Finally, it adds a sentence to "How to use callbacks" that makes more clear what goes on when the callbacks are printed.