### PR TITLE
Use show method for phase in `MetricsPrinter`

### DIFF
--- a/src/callbacks/callbacks.jl
+++ b/src/callbacks/callbacks.jl
@@ -56,7 +56,7 @@ end
 function print_epoch_table(mvhistory, epoch, phase)
     header = vcat(["Phase", "Epoch"], string.(keys(mvhistory)))
     vals = [last(mvhistory, key) |> last for key in keys(mvhistory)]
-    data = reshape(vcat([string(typeof(phase)), epoch], vals), 1, :)
+    data = reshape(vcat([string(phase), epoch], vals), 1, :)
     pretty_table(data; header = header, formatters = PrettyTables.ft_round(5))
 end
 


### PR DESCRIPTION
Currently, `MetricsPrinter` uses the type of the phase in the first column. This causes the table to overflow when the type is very long. In such cases, it is easy to provide a `Base.show` method to allow for shorter printing. This PR makes `MetricsPrinter` use the default `show` method for the phase.