### PR TITLE
fixed deprecation warning from improper Vararg use

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FluxTraining"
 uuid = "7bf95e4d-ca32-48da-9824-f0dc5310474f"
 authors = ["lorenzoh <lorenz.ohly@gmail.com>"]
-version = "0.3.6"
+version = "0.3.7"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/learner.jl
+++ b/src/learner.jl
@@ -74,11 +74,12 @@ function Learner(model, lossfn; callbacks = [], data = (), optimizer = ADAM(), k
 end
 
 
+# note that Vararg is covariant, using Vararg{<:Callback} produces warning
 """
     Learner(model, data, optimizer, lossfn, [callbacks...; kwargs...])
 """
 function Learner(
-        model, data, optimizer, lossfn, callbacks::Vararg{<:Callback};
+        model, data, optimizer, lossfn, callbacks::Vararg{Callback};
         usedefaultcallbacks=true, cbrunner=LinearRunner()
     )
     callbacks = collect(Callback, callbacks)


### PR DESCRIPTION
This fixes a deprecation warning caused by deprecated usage of `Vararg`.  The result looks somewhat confusing due to the specially covariant nature of `Vararg` and `Tuple` so I have inserted a comment to explain what's going on.  See additional discussion [in this Flux.jl PR](https://github.com/FluxML/Flux.jl/pull/2197).

### PR Checklist

- [x] Tests are added (covered by existing, none needed)
- [x] Documentation, if applicable (not applicable)
