### PR TITLE
Implement checkpointer that only saves top-k models.

### DIFF
--- a/src/FluxTraining.jl
+++ b/src/FluxTraining.jl
@@ -26,7 +26,7 @@ using ParameterSchedulers
 using TensorBoardLogger: TBLogger, log_value, log_image, log_text, log_histogram, tb_overwrite
 using Zygote: Grads, gradient
 using ValueHistories
-using DataStructures: DefaultDict
+using DataStructures: DefaultDict, PriorityQueue, enqueue!, dequeue!
 using PrettyTables
 using Setfield: @set
 

--- a/src/callbacks/logging/checkpointer.jl
+++ b/src/callbacks/logging/checkpointer.jl
@@ -4,14 +4,17 @@
     Checkpointer(folder)
 
 Saves `learner.model` to `folder` after every [`AbstractTrainingPhase`](#).
+If `keep_top_k` is provided, only the best k models (by smallest training loss) and the latest model are kept.
 
 Use `FluxTraining.`[`loadmodel`](#) to load a model.
 """
 struct Checkpointer <: Callback
     folder
-    function Checkpointer(folder)
+    keep_top_k::Union{Integer, Nothing}
+    top_k::PriorityQueue{<:AbstractString, <:Real}
+    function Checkpointer(folder; keep_top_k::Union{Integer, Nothing}=nothing)
         mkpath(folder)
-        return new(folder)
+        return new(folder, keep_top_k, PriorityQueue{String, Float64}(Base.Order.Reverse))
     end
 end
 
@@ -22,10 +25,35 @@ stateaccess(::Checkpointer) = (
 )
 
 function on(::EpochEnd, phase::AbstractTrainingPhase, checkpointer::Checkpointer, learner)
-    loss = last(learner.cbstate.metricsepoch[phase], :Loss)[2]
     epoch = learner.cbstate.history[phase].epochs
+    loss = last(learner.cbstate.metricsepoch[phase], :Loss)[2]
     filename = "checkpoint_epoch_$(lpad(string(epoch), 3, '0'))_loss_$loss.bson"
+
     savemodel(learner.model, joinpath(checkpointer.folder, filename))
+
+    if !isnothing(checkpointer.keep_top_k)
+        process_top_k_checkpoints(checkpointer, filename, loss)
+    end
+end
+
+try_fs_remove(path::String) =
+    try; Base.Filesystem.rm(path)
+    catch e; @warn e; end
+
+
+"Makes sure only the best k and the latest checkpoints are kept on disk.
+Note that priority queue may have k+1 elements, also tracking the latest model."
+function process_top_k_checkpoints(checkpointer::Checkpointer, new_checkpoint::String, new_loss::Real)
+    @assert length(checkpointer.top_k) <= checkpointer.keep_top_k+1
+    if length(checkpointer.top_k) > checkpointer.keep_top_k  # if previous model was not in top k
+        worst_checkpoint = dequeue!(checkpointer.top_k)
+        try_fs_remove(joinpath(checkpointer.folder, worst_checkpoint))
+    end
+    enqueue!(checkpointer.top_k, new_checkpoint=>new_loss)
+    if length(checkpointer.top_k) > checkpointer.keep_top_k && peek(checkpointer.top_k)[1] != new_checkpoint
+        worst_checkpoint = dequeue!(checkpointer.top_k)
+        try_fs_remove(joinpath(checkpointer.folder, worst_checkpoint))
+    end
 end
 
 

--- a/src/callbacks/logging/checkpointer.jl
+++ b/src/callbacks/logging/checkpointer.jl
@@ -14,6 +14,7 @@ struct Checkpointer <: Callback
     top_k::PriorityQueue{<:AbstractString, <:Real}
     function Checkpointer(folder; keep_top_k::Union{Integer, Nothing}=nothing)
         mkpath(folder)
+        # notice that in Julia, the PriorityQueue gives you elements with the *lowest* priority first
         return new(folder, keep_top_k, PriorityQueue{String, Float64}(Base.Order.Reverse))
     end
 end
@@ -41,9 +42,9 @@ try_fs_remove(path::String) =
     catch e; @warn e; end
 
 
-"Makes sure only the best k and the latest checkpoints are kept on disk.
-Note that priority queue may have k+1 elements, also tracking the latest model."
+"Makes sure only the best k and the latest checkpoints are kept on disk."
 function process_top_k_checkpoints(checkpointer::Checkpointer, new_checkpoint::String, new_loss::Real)
+    # Note that priority queue may have k+1 elements, also tracking the latest model.
     @assert length(checkpointer.top_k) <= checkpointer.keep_top_k+1
     if length(checkpointer.top_k) > checkpointer.keep_top_k  # if previous model was not in top k
         worst_checkpoint = dequeue!(checkpointer.top_k)

--- a/test/callbacks/checkpointer.jl
+++ b/test/callbacks/checkpointer.jl
@@ -8,3 +8,21 @@ include("../imports.jl")
     @test_nowarn fit!(learner, 5)
     @test length(readdir(checkpointer.folder)) == 5
 end
+
+@testset "`Checkpointer` with top_k models" begin
+    checkpointer = Checkpointer(mktempdir(); keep_top_k=8)
+    learner = testlearner(Recorder(), Metrics(), checkpointer)
+    @test length(readdir(checkpointer.folder)) == 0
+    @test_nowarn fit!(learner, 5)
+    @test length(readdir(checkpointer.folder)) == 5
+    @test_nowarn fit!(learner, 5)
+    @test length(readdir(checkpointer.folder)) == 8
+
+    learner.lossfn = (ŷ, y) -> 1e5
+    @test_nowarn fit!(learner, 1)
+    # make sure most recent model is still saved, even though it's bad
+    most_recent_loss = last(learner.cbstate.metricsepoch[TrainingPhase()], :Loss)[2]
+    @assert most_recent_loss == 1e5
+    @test any(contains(string(most_recent_loss)),
+              Base.Filesystem.readdir(checkpointer.folder))
+end

--- a/test/callbacks/checkpointer.jl
+++ b/test/callbacks/checkpointer.jl
@@ -18,9 +18,9 @@ end
     @test_nowarn fit!(learner, 5)
     @test length(readdir(checkpointer.folder)) == 8
 
+    # make sure most recent model is still saved, even though it's bad
     learner.lossfn = (ŷ, y) -> 1e5
     @test_nowarn fit!(learner, 1)
-    # make sure most recent model is still saved, even though it's bad
     most_recent_loss = last(learner.cbstate.metricsepoch[TrainingPhase()], :Loss)[2]
     @assert most_recent_loss == 1e5
     @test any(contains(string(most_recent_loss)),


### PR DESCRIPTION
Fixes #147.
When implementing this, there were a couple of considerations:
- storing only the best model, vs storing some top k models
- also always storing the latest model

I have decided that I would like both.
Storing top-k models is pretty easy by using a priority queue that tracks the current top_k models and that we can add to.
However, storing the latest model makes the logic a bit more complicated, since at any point we may track either k or k+1 models, depending on whether the latest model is in the top_k models.
I considered several ways to solve this, and the current implementation seems to be the least error prone. Open to suggestions though.

Tests, and a short docstring are provided. I'm not 100% sure if the docstring like this is correct - feel free to let me know.