### PR TITLE
fix Hard error on EarlyStopping()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /Manifest.toml
 **/.ipynb_checkpoints
 theme
+.vscode

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FluxTraining"
 uuid = "7bf95e4d-ca32-48da-9824-f0dc5310474f"
 authors = ["lorenzoh <lorenz.ohly@gmail.com>"]
-version = "0.3.9"
+version = "0.3.10"
 
 [deps]
 BSON = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"

--- a/src/training.jl
+++ b/src/training.jl
@@ -165,8 +165,17 @@ fit!(learner, 10, (traindl, valdl))
 """
 function fit!(learner, nepochs::Int, (trainiter, validiter))
     for i in 1:nepochs
-        epoch!(learner, TrainingPhase(), trainiter)
-        epoch!(learner, ValidationPhase(), validiter)
+        try
+            epoch!(learner, TrainingPhase(), trainiter)
+            epoch!(learner, ValidationPhase(), validiter)
+        catch e
+            if e isa CancelFittingException
+                @debug "Fitting canceled" error = e
+                break
+            else
+                rethrow()
+            end
+        end
     end
 end
 


### PR DESCRIPTION
#159

When executing `fit!`, this PR addresses a hard error when an EarlyStopping() criteria is met, which causes code termination followed by error crash. As such, `fit!` is rewritten to address the issue.